### PR TITLE
Fix duplicate UUID error

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/google/uuid"
 	"io"
 	"log"
 	"regexp"
@@ -129,8 +130,11 @@ func load(stmt *sql.Stmt, rawLine string, parsed, transformed shared.LogEntry, p
 		regexPattern = p.parseRegex.String()
 	}
 
+	id := uuid.New().String()
+
 	_, err := stmt.ExecContext(
 		ctx,
+		id,
 		traceID,
 		level,
 		message,

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -36,8 +36,8 @@ func setupTestDB(t *testing.T) (*sql.DB, *sql.Stmt, context.Context) {
 
 	stmt, err := db.Prepare(`
 		INSERT INTO logs (
-			trace_id, level, message, raw_log, parsed_log, log, created_at, timestamp, regex_pattern, jq_filter
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			id, trace_id, level, message, raw_log, parsed_log, log, created_at, timestamp, regex_pattern, jq_filter
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/logdb/db.go
+++ b/internal/logdb/db.go
@@ -50,6 +50,7 @@ func MustInit(path string, ctx context.Context) *sql.DB {
 func MustPrepareInsert(db *sql.DB, ctx context.Context) *sql.Stmt {
 	stmt, err := db.PrepareContext(ctx, `
 	INSERT INTO logs (
+	  id,
 	  trace_id,
 	  level,
 	  message,
@@ -60,7 +61,7 @@ func MustPrepareInsert(db *sql.DB, ctx context.Context) *sql.Stmt {
 	  timestamp,
 	  regex_pattern,
 	  jq_filter
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Occasionally we would get an error like this:

```
2025/05/01 20:55:36 ❌ Failed to insert log: Constraint Error: Duplicate key "id: a3fb2075-06b4-4a38-ba7f-a0c0bea0a12a" violates primary key constraint. If this is an unexpected constraint violation please double check with the known index limitations section in our documentation (https://duckdb.org/docs/sql/indexes).
```